### PR TITLE
fix(docker): use version-agnostic php binary for WP-CLI install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY --chown=nobody rootfs/ /
 
 # Install WP-CLI
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \
-    php84 wp-cli.phar --info && \
+    php wp-cli.phar --info && \
     chmod +x wp-cli.phar && \
     mv wp-cli.phar /usr/local/bin/wp
 


### PR DESCRIPTION
## Problem

The Docker build in CI is failing (on `main` too, not just PR #14) with:

```
ERROR: process "/bin/ash ... php84 wp-cli.phar --info ..." did not complete successfully: exit code: 127
```

`exit code: 127` = *command not found*. The base image `erseco/alpine-php-webserver:latest` is a floating tag that **bumped from PHP 8.4 to PHP 8.5**, so the `php84` binary no longer exists (it is now `php85`). The Dockerfile had it hardcoded.

This is **unrelated to PR #14** (the `actions/checkout` v6→v7 bump); that PR merely re-triggered the build and surfaced the pre-existing failure.

## Fix

Use the generic `php` symlink instead of `php84`, so the build survives future PHP version bumps of the base image.

## Verification

Local `docker build .` passes: WP-CLI 2.12.0 installed and WordPress 7.0 downloaded.