### PR TITLE
fix(ci): scope push trigger to main and tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: Build
 
 on:
   push:
+    branches:
+      - main
+    tags:
+      - '**'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Problem

The `Build` workflow was failing on every Dependabot branch push with:

```
Login to DockerHub
##[error]Username and password required
```

The DockerHub secrets (`DOCKER_USERNAME`, `DOCKER_PASSWORD`) **are** correctly configured as repository secrets. The real cause is the trigger context: Dependabot-triggered events run in an isolated security context that has **no access to Actions secrets** (only to the separate, empty *Dependabot secrets* store). Because Dependabot also fires a `push` event when it pushes its branch, the `if: github.event_name != 'pull_request'` guard did not skip the login step, so it ran with empty credentials.

## Fix

Scope the `push` trigger to the `main` branch and tags only:

```yaml
on:
  push:
    branches:
      - main
    tags:
      - '**'
  pull_request:
  workflow_dispatch:
```

## Effect

- **Dependabot branches** no longer fire a `push` build; they are validated only through their `pull_request` event, which already skips registry login/push.
- **PRs** still build + test (no push).
- **Pushes to `main` and tags** still log in and push images, with secrets available as before.
- Bonus: arbitrary branch pushes can no longer overwrite the `:latest` image on DockerHub.

## Note (not changed)

There is a secret-name inconsistency worth unifying later: the login step uses `DOCKER_PASSWORD` while the Docker Hub Description step uses `DOCKERHUB_PASSWORD`. Both secrets exist, so it works, but unifying would avoid confusion.