### PR TITLE
Prevent fork pull requests from running GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   buildx:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       # Step 1: Checkout the code


### PR DESCRIPTION
## Summary

- skip the Docker build and test job for pull requests originating from forks
- keep same-repository pull requests, pushes, tags, and manual runs working

## Security rationale

The workflow builds pull-request code with Docker, QEMU, Buildx, and Docker Compose. Blocking fork-originated jobs prevents untrusted code from consuming runner and network resources.