### PR TITLE
Restore CI for approved fork pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   buildx:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       # Step 1: Checkout the code


### PR DESCRIPTION
## Summary

- revert the fork-specific CI restriction introduced in #17
- allow normal pull request CI to run after GitHub's external-contributor approval gate

## Rationale

The repository should use **Require approval for all external contributors**. This preserves manual approval while allowing maintainers to run CI for legitimate external contributions.